### PR TITLE
Add useDateFormat hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Find the hook you want to use and copy the link to install the hook into your pr
 
 - [useIsOnline](#useisonline) - Check if the user is online
 
+### Date & Time
+
+- [useDateFormat](#usedateformat) - Format dates with customizable patterns and locales
+
 ### useIsOnline
 
 Check if the user is online.
@@ -806,4 +810,143 @@ function ScrollInfo() {
 
 ```bash
 npx shadcn@latest add https://hookas.letstri.dev/r/use-scroll-info.json
+```
+
+### useDateFormat
+
+Format dates with customizable patterns and locales. Supports a wide range of format tokens for year, month, day, hour, minute, second, millisecond, meridiem, weekday, and timezone formatting.
+
+#### Usage
+
+```tsx
+import { useDateFormat } from '@/hookas/use-date-format'
+
+function DateDisplay() {
+  const date = new Date()
+
+  // Basic formatting
+  const formattedTime = useDateFormat(date, 'HH:mm:ss')
+  const formattedDate = useDateFormat(date, 'YYYY-MM-DD')
+  const fullFormat = useDateFormat(date, 'dddd, MMMM Do, YYYY [at] h:mm A')
+
+  return (
+    <div>
+      <p>Time: {formattedTime}</p>
+      <p>Date: {formattedDate}</p>
+      <p>Full: {fullFormat}</p>
+    </div>
+  )
+}
+
+// With custom locale
+function LocalizedDate() {
+  const date = new Date()
+  const frenchDate = useDateFormat(date, 'dddd, DD MMMM YYYY', {
+    locales: 'fr-FR'
+  })
+
+  return <p>{frenchDate}</p>
+}
+
+// With custom meridiem
+function CustomMeridiem() {
+  const date = new Date()
+  const customTime = useDateFormat(date, 'h:mm a', {
+    customMeridiem: (hours, minutes, isLowercase) => {
+      const period = hours < 12 ? 'Morning' : 'Evening'
+      return isLowercase ? period.toLowerCase() : period
+    }
+  })
+
+  return <p>{customTime}</p>
+}
+
+// Dynamic date formatting
+function DynamicFormat() {
+  const [format, setFormat] = useState('YYYY-MM-DD')
+  const [date] = useState(new Date())
+
+  const formatted = useDateFormat(date, format)
+
+  return (
+    <div>
+      <select value={format} onChange={(e) => setFormat(e.target.value)}>
+        <option value="YYYY-MM-DD">ISO Date</option>
+        <option value="MM/DD/YYYY">US Format</option>
+        <option value="DD/MM/YYYY">EU Format</option>
+        <option value="dddd, MMMM Do, YYYY">Full Date</option>
+        <option value="h:mm:ss A">12-hour Time</option>
+        <option value="HH:mm:ss">24-hour Time</option>
+      </select>
+      <p>Formatted: {formatted}</p>
+    </div>
+  )
+}
+```
+
+#### Format Tokens
+
+The hook supports a comprehensive set of format tokens:
+
+**Year:**
+- `YYYY` - 4-digit year (2024)
+- `YY` - 2-digit year (24)
+- `Yo` - Ordinal year (2024th)
+
+**Month:**
+- `M` - Month number (1-12)
+- `MM` - Zero-padded month (01-12)
+- `MMM` - Short month name (Jan, Feb, Mar)
+- `MMMM` - Full month name (January, February, March)
+- `Mo` - Ordinal month (1st, 2nd, 3rd)
+
+**Day:**
+- `D` - Day of month (1-31)
+- `DD` - Zero-padded day (01-31)
+- `Do` - Ordinal day (1st, 2nd, 3rd)
+
+**Weekday:**
+- `d` - Day of week number (0-6, Sunday=0)
+- `dd` - Narrow weekday name (S, M, T)
+- `ddd` - Short weekday name (Sun, Mon, Tue)
+- `dddd` - Full weekday name (Sunday, Monday, Tuesday)
+
+**Hour:**
+- `H` - 24-hour format (0-23)
+- `HH` - Zero-padded 24-hour (00-23)
+- `h` - 12-hour format (1-12)
+- `hh` - Zero-padded 12-hour (01-12)
+- `Ho` - Ordinal 24-hour (0th, 1st, 2nd)
+- `ho` - Ordinal 12-hour (12th, 1st, 2nd)
+
+**Minute:**
+- `m` - Minutes (0-59)
+- `mm` - Zero-padded minutes (00-59)
+- `mo` - Ordinal minutes (0th, 1st, 2nd)
+
+**Second:**
+- `s` - Seconds (0-59)
+- `ss` - Zero-padded seconds (00-59)
+- `so` - Ordinal seconds (0th, 1st, 2nd)
+
+**Millisecond:**
+- `SSS` - Zero-padded milliseconds (000-999)
+
+**Meridiem:**
+- `A` - Uppercase meridiem (AM, PM)
+- `AA` - Uppercase with periods (A.M., P.M.)
+- `a` - Lowercase meridiem (am, pm)
+- `aa` - Lowercase with periods (a.m., p.m.)
+
+**Timezone:**
+- `z`, `zz`, `zzz` - Short timezone offset (+05:30)
+- `zzzz` - Long timezone offset (+05:30)
+
+**Escaping:**
+- `[text]` - Escaped text that won't be formatted
+
+#### Install
+
+```bash
+npx shadcn@latest add https://hookas.letstri.dev/r/use-date-format.json
 ```

--- a/registry/hooks/use-date-format.ts
+++ b/registry/hooks/use-date-format.ts
@@ -1,0 +1,122 @@
+import { useMemo } from 'react'
+
+export type DateLike = Date | number | string | undefined
+
+export interface UseDateFormatOptions {
+  /**
+   * The locale(s) to used for dd/ddd/dddd/MMM/MMMM format
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+   */
+  locales?: Intl.LocalesArgument
+
+  /**
+   * A custom function to re-modify the way to display meridiem
+   *
+   */
+  customMeridiem?: (hours: number, minutes: number, isLowercase?: boolean, hasPeriod?: boolean) => string
+}
+
+// eslint-disable-next-line regexp/no-misleading-capturing-group
+const REGEX_PARSE = /* #__PURE__ */ /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[T\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/i
+const REGEX_FORMAT = /* #__PURE__ */ /[YMDHhms]o|\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a{1,2}|A{1,2}|m{1,2}|s{1,2}|Z{1,2}|z{1,4}|SSS/g
+
+function defaultMeridiem(hours: number, minutes: number, isLowercase?: boolean, hasPeriod?: boolean) {
+  let m = (hours < 12 ? 'AM' : 'PM')
+  if (hasPeriod)
+    m = m.split('').reduce((acc, curr) => acc += `${curr}.`, '')
+  return isLowercase ? m.toLowerCase() : m
+}
+
+function formatOrdinal(num: number) {
+  const suffixes = ['th', 'st', 'nd', 'rd']
+  const v = num % 100
+  return num + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0])
+}
+
+export function formatDate(date: Date, formatStr: string, options: UseDateFormatOptions = {}) {
+  const years = date.getFullYear()
+  const month = date.getMonth()
+  const days = date.getDate()
+  const hours = date.getHours()
+  const minutes = date.getMinutes()
+  const seconds = date.getSeconds()
+  const milliseconds = date.getMilliseconds()
+  const day = date.getDay()
+  const meridiem = options.customMeridiem ?? defaultMeridiem
+  const stripTimeZone = (dateString: string) => {
+    return dateString.split(' ')[1] ?? ''
+  }
+  const matches: Record<string, () => string | number> = {
+    Yo: () => formatOrdinal(years),
+    YY: () => String(years).slice(-2),
+    YYYY: () => years,
+    M: () => month + 1,
+    Mo: () => formatOrdinal(month + 1),
+    MM: () => `${month + 1}`.padStart(2, '0'),
+    MMM: () => date.toLocaleDateString(options.locales, { month: 'short' }),
+    MMMM: () => date.toLocaleDateString(options.locales, { month: 'long' }),
+    D: () => String(days),
+    Do: () => formatOrdinal(days),
+    DD: () => `${days}`.padStart(2, '0'),
+    H: () => String(hours),
+    Ho: () => formatOrdinal(hours),
+    HH: () => `${hours}`.padStart(2, '0'),
+    h: () => `${hours % 12 || 12}`.padStart(1, '0'),
+    ho: () => formatOrdinal(hours % 12 || 12),
+    hh: () => `${hours % 12 || 12}`.padStart(2, '0'),
+    m: () => String(minutes),
+    mo: () => formatOrdinal(minutes),
+    mm: () => `${minutes}`.padStart(2, '0'),
+    s: () => String(seconds),
+    so: () => formatOrdinal(seconds),
+    ss: () => `${seconds}`.padStart(2, '0'),
+    SSS: () => `${milliseconds}`.padStart(3, '0'),
+    d: () => day,
+    dd: () => date.toLocaleDateString(options.locales, { weekday: 'narrow' }),
+    ddd: () => date.toLocaleDateString(options.locales, { weekday: 'short' }),
+    dddd: () => date.toLocaleDateString(options.locales, { weekday: 'long' }),
+    A: () => meridiem(hours, minutes),
+    AA: () => meridiem(hours, minutes, false, true),
+    a: () => meridiem(hours, minutes, true),
+    aa: () => meridiem(hours, minutes, true, true),
+    z: () => stripTimeZone(date.toLocaleDateString(options.locales, { timeZoneName: 'shortOffset' })),
+    zz: () => stripTimeZone(date.toLocaleDateString(options.locales, { timeZoneName: 'shortOffset' })),
+    zzz: () => stripTimeZone(date.toLocaleDateString(options.locales, { timeZoneName: 'shortOffset' })),
+    zzzz: () => stripTimeZone(date.toLocaleDateString(options.locales, { timeZoneName: 'longOffset' })),
+  }
+  return formatStr.replace(REGEX_FORMAT, (match, $1) => $1 ?? matches[match]?.() ?? match)
+}
+
+export function normalizeDate(date: DateLike) {
+  if (date === null)
+    return new Date(Number.NaN) // null is invalid
+  if (date === undefined)
+    return new Date()
+  if (date instanceof Date)
+    return new Date(date)
+  if (typeof date === 'string' && !/Z$/i.test(date)) {
+    const d = date.match(REGEX_PARSE) as any
+    if (d) {
+      const m = d[2] - 1 || 0
+      const ms = (d[7] || '0').substring(0, 3)
+      return new Date(d[1], m, d[3]
+        || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+    }
+  }
+
+  return new Date(date)
+}
+
+export type UseDateFormatReturn = string
+
+/**
+ * Get the formatted date according to the string of tokens passed in.
+ *
+ * @param date - The date to format, can either be a `Date` object, a timestamp, or a string
+ * @param formatStr - The combination of tokens to format the date
+ * @param options - UseDateFormatOptions
+ */
+export function useDateFormat(date: DateLike, formatStr: string = 'HH:mm:ss', options: UseDateFormatOptions = {}): UseDateFormatReturn {
+  return useMemo(() => formatDate(normalizeDate(date), formatStr, options), [date, formatStr, options])
+}


### PR DESCRIPTION
- adds a new react hook that formats dates using customizable token patterns (like YYYY-MM-DD, HH:mm:ss)
- supports multiple locales, custom meridiem formatting, and handles various date input types including strings, timestamps, and date objects. 
- includes ordinal formatting (1st, 2nd, 3rd) and timezone display options.